### PR TITLE
various fixes / additions to math node. --- Pass 1

### DIFF
--- a/nodes/number/math.py
+++ b/nodes/number/math.py
@@ -57,6 +57,14 @@ def as_int(x1: Number = 1.0, x2: Number = 2.0) -> Int:
 def round_n(x: Number = 0.0, y: Int = 0) -> Float:
     return x.round(y)
 
+@node_func(id=18)
+def modulo(x1: Number = 1.0, x2: Number = 1.0) -> Float:
+    return np.mod(x1, x2)
+
+@node_func(id=19)
+def fmodulo(x1: Number = 1.0, x2: Number = 1.0) -> Float:
+    return np.fmod(x1, x2)
+
 @node_func(id=20)
 def ceil(x: Number = 1.0) -> Float:
     return np.ceil(x)

--- a/nodes/number/math.py
+++ b/nodes/number/math.py
@@ -69,13 +69,26 @@ def pow(x: Number = 1.0, y: Int = 2) -> Number:
 def exp(x: Number = 1.0) -> Number:
     return np.exp(x)
 
-# each element individually compared returns smallest
+@node_func(id=25)
+def ln(x: Number = 1.0) -> Number:
+    return np.log(x)
+
 @node_func(id=26)
+def log10(x: Number = 1.0) -> Number:
+    return np.log10(x)
+
+@node_func(id=27)
+def logn(x1: Number = 1.0, x2: Number = 1.0) -> Number:
+    return np.logn(x1, x2)
+
+
+# each element individually compared returns smallest
+@node_func(id=30)
 def minimum(x1: Number = 1.0, x2: Number = -1.0) -> Number:
     return np.minimum(x1, x2)
 
 # each element individually compared returns largest
-@node_func(id=27)
+@node_func(id=31)
 def maximum(x1: Number = 1.0, x2: Number = -1.0) -> Number:
     return np.maximum(x1, x2)
 

--- a/nodes/number/math.py
+++ b/nodes/number/math.py
@@ -10,19 +10,19 @@ from svrx.util.function import constant
 # pylint: disable=W0622
 
 @node_func(bl_idname='SvRxNodeMath', multi_label="Math", id=0, cls_bases=(NodeMathBase,))
-def add(x: Number = 0.0, y: Number = 0.0) -> Number:
+def add(x: Number = 0.0, y: Number = 1.0) -> Number:
     return x + y
 
 @node_func(id=1)
-def sub(x: Number = 0.0, y: Number = 0.0) -> Number:
+def sub(x: Number = 0.0, y: Number = 1.0) -> Number:
     return x - y
 
 @node_func(id=2)
-def mul(x: Number = 0.0, y: Number = 0.0) -> Number:
+def mul(x: Number = 0.0, y: Number = 2.0) -> Number:
     return x * y
 
 @node_func(id=3)
-def div(x: Number = 2.0, y: Number = 1.0) -> Number:
+def div(x: Number = 1.0, y: Number = 2.0) -> Number:
     return x / y
 
 @node_func(id=4)
@@ -45,32 +45,12 @@ def reciprocal(x: Number = 1.0) -> Number:
 def negate(x: Number = 0.0) -> Number:
     return -x
 
-@node_func(id=11)
-def add_1(x: Number = 0.0) -> Number:
-    return x + 1
-
-@node_func(id=12)
-def sub_1(x: Number = 0.0) -> Number:
-    return x - 1
-
-@node_func(id=13)
-def div_2(x: Number = 0.0) -> Number:
-    return x / 2
-
-@node_func(id=14)
-def mul_2(x: Number = 0.0) -> Number:
-    return x * 2
-
 @node_func(id=15)
 def as_int(x: Number = 0.0) -> Int:
     return x.astype(int)
 
-@node_func(id=16)
-def round(x: Number = 0.0) -> Float:
-    return x.round()
-
 @node_func(id=17)
-def round_n(x: Number = 0.0, y: Int = 3) -> Float:
+def round_n(x: Number = 0.0, y: Int = 0) -> Float:
     return x.round(y)
 
 

--- a/nodes/number/math.py
+++ b/nodes/number/math.py
@@ -67,7 +67,7 @@ def as_int(x: Number = 0.0) -> Int:
 
 @node_func(id=16)
 def round(x: Number = 0.0) -> Float:
-    return x.round(1)
+    return x.round(0)
 
 @node_func(id=17)
 def round_n(x: Number = 0.0, y: Int = 3) -> Float:

--- a/nodes/number/math.py
+++ b/nodes/number/math.py
@@ -67,7 +67,7 @@ def as_int(x: Number = 0.0) -> Int:
 
 @node_func(id=16)
 def round(x: Number = 0.0) -> Float:
-    return x.round(0)
+    return x.round()
 
 @node_func(id=17)
 def round_n(x: Number = 0.0, y: Int = 3) -> Float:

--- a/nodes/number/math.py
+++ b/nodes/number/math.py
@@ -39,6 +39,7 @@ def absolute(x: Number = -1.0) -> Number:
 
 @node_func(id=9)
 def reciprocal(x: Number = 1.0) -> Number:
+    # numpy.reciprocal  is not designed to work with integers.
     return 1 / x
 
 @node_func(id=10)

--- a/nodes/number/math.py
+++ b/nodes/number/math.py
@@ -75,7 +75,7 @@ def floor(x: Number = 1.5) -> Float:
     return np.floor(x)
 
 @node_func(id=22)
-def pow(x: Number = 1.0, y: Int = 2) -> Number:
+def pow(x: Number = 1.0, y: Number = 2.0) -> Number:
     return np.power(x, y)
 
 @node_func(id=24)

--- a/nodes/number/math.py
+++ b/nodes/number/math.py
@@ -49,6 +49,10 @@ def negate(x: Number = 0.0) -> Number:
 def as_int(x: Number = 0.0) -> Int:
     return x.astype(int)
 
+@node_func(id=16)
+def as_int(x1: Number = 1.0, x2: Number = 2.0) -> Int:
+    return np.floor_divide(x1, x2)
+
 @node_func(id=17)
 def round_n(x: Number = 0.0, y: Int = 0) -> Float:
     return x.round(y)
@@ -58,7 +62,7 @@ def ceil(x: Number = 1.0) -> Float:
     return np.ceil(x)
 
 @node_func(id=21)
-def ceil(x: Number = 1.5) -> Float:
+def floor(x: Number = 1.5) -> Float:
     return np.floor(x)
 
 @node_func(id=22)
@@ -78,7 +82,7 @@ def log10(x: Number = 1.0) -> Number:
     return np.log10(x)
 
 @node_func(id=27)
-def logn(x1: Number = 1.0, x2: Number = 1.0) -> Number:
+def logn(x1: Number = 1.0, x2: Number = 2.0) -> Number:
     return np.logn(x1, x2)
 
 

--- a/nodes/number/math.py
+++ b/nodes/number/math.py
@@ -53,10 +53,29 @@ def as_int(x: Number = 0.0) -> Int:
 def round_n(x: Number = 0.0, y: Int = 0) -> Float:
     return x.round(y)
 
-
 @node_func(id=20)
 def ceil(x: Number = 1.0) -> Float:
     return np.ceil(x)
+
+@node_func(id=22)
+def pow(x: Number = 1.0, y: Int = 2) -> Number:
+    return np.power(x, y)
+
+@node_func(id=24)
+def exp(x: Number = 1.0) -> Number:
+    return np.exp(x)
+
+# each element individually compared returns smallest
+@node_func(id=26)
+def minimum(x1: Number = 1.0, x2: Number = -1.0) -> Number:
+    return np.minimum(x1, x2)
+
+# each element individually compared returns largest
+@node_func(id=26)
+def maximum(x1: Number = 1.0, x2: Number = -1.0) -> Number:
+    return np.maximum(x1, x2)
+
+
 
 
 @node_func(id=61)

--- a/nodes/number/math.py
+++ b/nodes/number/math.py
@@ -31,7 +31,7 @@ def sqrt(x: Number = 1.0) -> Number:
 
 @node_func(id=5)
 def copy_sign(x: Number = 1.0, y: Number = -1.0) -> Number:
-    return np.copy_sign(x, y)
+    return np.copysign(x, y)
 
 @node_func(id=6)
 def absolute(x: Number = -1.0) -> Number:

--- a/nodes/number/math.py
+++ b/nodes/number/math.py
@@ -71,7 +71,7 @@ def minimum(x1: Number = 1.0, x2: Number = -1.0) -> Number:
     return np.minimum(x1, x2)
 
 # each element individually compared returns largest
-@node_func(id=26)
+@node_func(id=27)
 def maximum(x1: Number = 1.0, x2: Number = -1.0) -> Number:
     return np.maximum(x1, x2)
 

--- a/nodes/number/math.py
+++ b/nodes/number/math.py
@@ -57,6 +57,10 @@ def round_n(x: Number = 0.0, y: Int = 0) -> Float:
 def ceil(x: Number = 1.0) -> Float:
     return np.ceil(x)
 
+@node_func(id=21)
+def ceil(x: Number = 1.5) -> Float:
+    return np.floor(x)
+
 @node_func(id=22)
 def pow(x: Number = 1.0, y: Int = 2) -> Number:
     return np.power(x, y)


### PR DESCRIPTION
pushing early to have something to work with..

See below a list of issues encountered during rudimentary testing. Some of these will make it into the eventual docs highlighting the potentially unexpected behavior.

---------

The modes of math node

- [x]  SQRT
-  [x] NEG
-  [x] SUB
-  [x] MUL
- [x]  ADD
-  [x] DIV
    - div autoconverts for instance 180/60 into `3.` (float)  ... use INTDIV if you know that the two values will divide without remainder, or if you don't care about the remainder.
- [x] ABS
- [x] CEIL
    - outputs a float
- [X] COPY SIGN
    - copysign autoconverts ints to float output. (I think this is not expected behaviour)
- [x] ROUND-N
- [x] FMOD
-  [x] MODULO
-  [x] FLOOR
-  [x] EXP
-  [x] LN
-  [x] LOG1P
-  [x] LOG10
-  [x] INTDIV
-  [x] POW
-  [x] E
-  [x] MIN
-  [x] MAX
- [x] 1/x

_are not_ implemented in this node, instead their counterparts use sane defaults to produce the same results.

-  ROUND
-  POW2
-  `-1`
-  `+1`
-  `*2`
-  `/2`
